### PR TITLE
Refactoring workout result model -> custom type

### DIFF
--- a/VirtualTrainer/FeedbackViewController.swift
+++ b/VirtualTrainer/FeedbackViewController.swift
@@ -29,22 +29,14 @@ class FeedbackViewController: UIViewController {
     
     @IBAction func finish(_ sender: Any) {
         _ = navigationController?.popToRootViewController(animated: true)
-        let item = WorkoutResultModel(
-                score: 1020,
-                incorrectJoints: [],
-                incorrectAccelerations: [])
-        Amplify.DataStore.save(item) { result in
-            switch(result) {
-            case .success(let savedItem):
-                print("Saved item: \(savedItem.id)")
-            case .failure(let error):
-                print("Could not save item to DataStore: \(error)")
-            }
-        }
-        
+
         print(workoutSession?.squatElements)
         print(workoutSession?.deadliftElements)
-        workoutSession?.workoutResult = item
+        workoutSession?.workoutResult = WorkoutResult(
+          score: 1020,
+          incorrectJoints: [],
+          incorrectAccelerations: []
+        )
         workoutSession?.endTimestamp = NSDate().timeIntervalSince1970
         workoutSession?.save()
     }

--- a/VirtualTrainer/HistoryViewController.swift
+++ b/VirtualTrainer/HistoryViewController.swift
@@ -167,7 +167,7 @@ class HistoryViewController: UIViewController, UINavigationControllerDelegate, U
       let workoutSession = WorkoutSession(workoutType: model.workoutType, cameraAngle: model.cameraAngle)
       workoutSession.id = model.id
       workoutSession.imuData = model.imuData
-      workoutSession.workoutResult = model.result ?? WorkoutResultModel(
+      workoutSession.workoutResult = model.workoutResult ?? WorkoutResult(
         score: 0,
         incorrectJoints: [0],
         incorrectAccelerations: [0]

--- a/VirtualTrainer/WorkoutResult.swift
+++ b/VirtualTrainer/WorkoutResult.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Google Inc. All rights reserved.
 //
 
-struct WorkoutResult {
+public struct WorkoutResult: Codable {
   var score: Int?
   var incorrectJoints: [Double]?
   var incorrectAccelerations: [Double]?

--- a/VirtualTrainer/WorkoutSession.swift
+++ b/VirtualTrainer/WorkoutSession.swift
@@ -11,7 +11,7 @@ class WorkoutSession {
   var workoutType: String = ""
   var imuData: [Double] = []
   var cameraAngle: String
-  var workoutResult: WorkoutResultModel
+  var workoutResult: WorkoutResult
   var startTimestamp: Double = 0
   var endTimestamp: Double = 0
   var squatElements: [SquatElement] = []
@@ -20,53 +20,45 @@ class WorkoutSession {
   init(workoutType: String, cameraAngle: String) {
     self.workoutType = workoutType
     self.cameraAngle = cameraAngle
-    self.workoutResult = WorkoutResultModel(score: 0, incorrectJoints: [0], incorrectAccelerations: [0])
+    self.workoutResult = WorkoutResult(score: 0, incorrectJoints: [0], incorrectAccelerations: [0])
     self.startTimestamp = NSDate().timeIntervalSince1970
   }
   
-  func compare() -> WorkoutResultModel {
-    let k = IdealWorkoutModel.keys
-    
-    Amplify.DataStore.query(IdealWorkoutModel.self, where: k.workoutType == workoutType) { result in
-      switch(result) {
-      case .success(let items):
-        for item in items {
-            print("IdealWorkoutModel ID: \(item.id)")
+//  func compare() -> WorkoutResultModel {
+//    let k = IdealWorkoutModel.keys
+//
+//    Amplify.DataStore.query(IdealWorkoutModel.self, where: k.workoutType == workoutType) { result in
+//      switch(result) {
+//      case .success(let items):
+//        for item in items {
+//            print("IdealWorkoutModel ID: \(item.id)")
 //            do comparison here
-        }
-      case .failure(let error):
-          print("Could not query DataStore: \(error)")
-        }
-      }
-    
-    let workoutResultItem = WorkoutResultModel(
-        score: 1020,
-        incorrectJoints: [0],
-        incorrectAccelerations: [0])
-    Amplify.DataStore.save(workoutResultItem) { result in
-        switch(result) {
-        case .success(let savedItem):
-          print("Saved workout result: \(savedItem.id)")
-          self.workoutResult = savedItem
-        case .failure(let error):
-          print("Could not save workout result to DataStore: \(error)")
-        }
-    }
-    
-    return workoutResultItem
-  }
+//        }
+//      case .failure(let error):
+//          print("Could not query DataStore: \(error)")
+//        }
+//      }
+//
+//    self.workoutResult = WorkoutResult(
+//        score: 1020,
+//        incorrectJoints: [0],
+//        incorrectAccelerations: [0])
+//    )
+//
+//    return workoutResultItem
+//  }
   
   func save() -> Bool {
-    print(self.workoutType)
+    print(self.workoutResult)
     let workoutSessionItem = WorkoutSessionModel(
       imuData: self.imuData,
       cameraAngle: self.cameraAngle,
       workoutType: self.workoutType,
-      result: self.workoutResult,
       startTimestamp: Int(self.startTimestamp),
       endTimestamp: Int(self.endTimestamp),
       squatElements: self.squatElements,
-      deadliftElements: self.deadliftElements)
+      deadliftElements: self.deadliftElements,
+      workoutResult: self.workoutResult)
     Amplify.DataStore.save(workoutSessionItem) { result in
       switch(result) {
       case .success(let savedItem):

--- a/VirtualTrainer/WorkoutTableViewCell.swift
+++ b/VirtualTrainer/WorkoutTableViewCell.swift
@@ -27,6 +27,6 @@ class WorkoutTableViewCell: UITableViewCell {
       
       typeLabel?.text = session.workoutType.capitalized
       dateLabel?.text = strDate
-        accuracyLabel?.text = String(session.workoutResult.score)
+      accuracyLabel?.text = String(session.workoutResult.score ?? 0)
     }
 }

--- a/amplify/backend/api/amplifyDatasource/schema.graphql
+++ b/amplify/backend/api/amplifyDatasource/schema.graphql
@@ -1,3 +1,9 @@
+type WorkoutResult {
+  score: Int!
+  incorrectJoints: [Float]
+  incorrectAccelerations: [Float]
+}
+
 type DeadliftElement {
   orientation: String!
   rightKneeAngle: Float!
@@ -27,11 +33,11 @@ type WorkoutSessionModel @model @auth(rules: [{allow: public}]) {
   imuData: [Float!]
   cameraAngle: String!
   workoutType: String!
-  result: WorkoutResultModel @connection
   startTimestamp: AWSTimestamp!
   endTimestamp: AWSTimestamp!
   squatElements: [SquatElement]
   deadliftElements: [DeadliftElement]
+  workoutResult: WorkoutResult
 }
 
 type WorkoutResultModel @model @auth(rules: [{allow: public}]) {

--- a/amplify/generated/models/AmplifyModels.swift
+++ b/amplify/generated/models/AmplifyModels.swift
@@ -5,7 +5,7 @@ import Foundation
 // Contains the set of classes that conforms to the `Model` protocol. 
 
 final public class AmplifyModels: AmplifyModelRegistration {
-  public let version: String = "1b66e447581d49c0c22fef80cebcca8c"
+  public let version: String = "2b222191cbd877bd9e3b5b85453fcc80"
   
   public func registerModels(registry: ModelRegistry.Type) {
     ModelRegistry.register(modelType: WorkoutSessionModel.self)

--- a/amplify/generated/models/WorkoutResult+Schema.swift
+++ b/amplify/generated/models/WorkoutResult+Schema.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension WorkoutResult {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case score
+    case incorrectJoints
+    case incorrectAccelerations
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let workoutResult = WorkoutResult.keys
+    
+    model.pluralName = "WorkoutResults"
+    
+    model.fields(
+      .field(workoutResult.score, is: .required, ofType: .int),
+      .field(workoutResult.incorrectJoints, is: .optional, ofType: .embeddedCollection(of: Double.self)),
+      .field(workoutResult.incorrectAccelerations, is: .optional, ofType: .embeddedCollection(of: Double.self))
+    )
+    }
+}

--- a/amplify/generated/models/WorkoutResult.swift
+++ b/amplify/generated/models/WorkoutResult.swift
@@ -1,0 +1,9 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct WorkoutResult: Embeddable {
+  var score: Int
+  var incorrectJoints: [Double]?
+  var incorrectAccelerations: [Double]?
+}

--- a/amplify/generated/models/WorkoutSessionModel+Schema.swift
+++ b/amplify/generated/models/WorkoutSessionModel+Schema.swift
@@ -9,11 +9,11 @@ extension WorkoutSessionModel {
     case imuData
     case cameraAngle
     case workoutType
-    case result
     case startTimestamp
     case endTimestamp
     case squatElements
     case deadliftElements
+    case workoutResult
   }
   
   public static let keys = CodingKeys.self
@@ -29,11 +29,11 @@ extension WorkoutSessionModel {
       .field(workoutSessionModel.imuData, is: .required, ofType: .embeddedCollection(of: Double.self)),
       .field(workoutSessionModel.cameraAngle, is: .required, ofType: .string),
       .field(workoutSessionModel.workoutType, is: .required, ofType: .string),
-      .belongsTo(workoutSessionModel.result, is: .optional, ofType: WorkoutResultModel.self, targetName: "workoutSessionModelResultId"),
       .field(workoutSessionModel.startTimestamp, is: .required, ofType: .int),
       .field(workoutSessionModel.endTimestamp, is: .required, ofType: .int),
       .field(workoutSessionModel.squatElements, is: .optional, ofType: .embeddedCollection(of: SquatElement.self)),
-      .field(workoutSessionModel.deadliftElements, is: .optional, ofType: .embeddedCollection(of: DeadliftElement.self))
+      .field(workoutSessionModel.deadliftElements, is: .optional, ofType: .embeddedCollection(of: DeadliftElement.self)),
+      .field(workoutSessionModel.workoutResult, is: .optional, ofType: .embedded(type: WorkoutResult.self))
     )
     }
 }

--- a/amplify/generated/models/WorkoutSessionModel.swift
+++ b/amplify/generated/models/WorkoutSessionModel.swift
@@ -7,29 +7,29 @@ public struct WorkoutSessionModel: Model {
   public var imuData: [Double]
   public var cameraAngle: String
   public var workoutType: String
-  public var result: WorkoutResultModel?
   public var startTimestamp: Int
   public var endTimestamp: Int
   public var squatElements: [SquatElement]?
   public var deadliftElements: [DeadliftElement]?
+  public var workoutResult: WorkoutResult?
   
   public init(id: String = UUID().uuidString,
       imuData: [Double] = [],
       cameraAngle: String,
       workoutType: String,
-      result: WorkoutResultModel? = nil,
       startTimestamp: Int,
       endTimestamp: Int,
       squatElements: [SquatElement]? = [],
-      deadliftElements: [DeadliftElement]? = []) {
+      deadliftElements: [DeadliftElement]? = [],
+      workoutResult: WorkoutResult? = nil) {
       self.id = id
       self.imuData = imuData
       self.cameraAngle = cameraAngle
       self.workoutType = workoutType
-      self.result = result
       self.startTimestamp = startTimestamp
       self.endTimestamp = endTimestamp
       self.squatElements = squatElements
       self.deadliftElements = deadliftElements
+      self.workoutResult = workoutResult
   }
 }


### PR DESCRIPTION
Replacing the workout result model with a simpler custom type so we don't have to save a workout result to Amplify Datastore every time.